### PR TITLE
Fix the version 2 release command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "check": "bun run typecheck && bun run test && bun run build",
-    "release": "changeset publish --access public",
+    "release": "changeset publish",
     "prepublishOnly": "bun run check"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- remove the obsolete Changesets v3 --access argument
- continue using the package publishConfig setting for public npm access

## Validation

- Changesets publish help accepts the updated command
- typechecking, 14 unit tests, and both package builds pass